### PR TITLE
Merge UIR-034 mediation and VAI-533 e2e onto main

### DIFF
--- a/hallucinate_app/node/dashboard/content_browser/search_interface.js
+++ b/hallucinate_app/node/dashboard/content_browser/search_interface.js
@@ -8,7 +8,7 @@
  */
 
 /**
- * Interop contract advertised for VAI-674 / VAIOS-G707: proves that the
+ * Interop contract advertised for HAO-740 / VAIOS-G707: proves that the
  * Hallucinate App desktop search surface can hand off a search request to
  * the mobile ORB bridge (`mobile/src/orb/metaGlassesOrbDescriptors.js`)
  * through the shared control-surface contract.
@@ -32,8 +32,9 @@ export const HALLUCINATE_APP_MOBILE_INTEROP_DESCRIPTOR = {
   descriptor_id: 'hallucinate-app-mobile-interop@0.1.0',
   interface_contract: HALLUCINATE_APP_MOBILE_SEARCH_INTEROP_CONTRACT.contract_id,
   goal_id: 'VAIOS-G707',
-  task_id: 'VAI-674',
-  repair_task_id: 'VAI-684',
+  task_id: 'HAO-740',
+  repair_task_id: 'HAO-740',
+  related_repair_task_id: 'HAO-751',
   source_surface: HALLUCINATE_APP_MOBILE_SEARCH_INTEROP_CONTRACT.source_surface,
   target_surface: HALLUCINATE_APP_MOBILE_SEARCH_INTEROP_CONTRACT.target_surface,
   control_surface_contract_ref:
@@ -56,14 +57,24 @@ export const HALLUCINATE_APP_MOBILE_INTEROP_DESCRIPTOR = {
   },
   validation: {
     objective_gap_ref:
-      'data/virtual_ai_os/discovery/2026-07-08-vai-674-objective-gap-7edb316279e5.md',
+      'data/hallucinate_multimodal_control/discovery/2026-07-08-hao-740-objective-gap-7edb316279e5.md',
     validation_confirmation_ref:
-      'data/virtual_ai_os/discovery/2026-07-08-vai-674-attempt-8-validation-confirmation.md',
+      'data/hallucinate_multimodal_control/discovery/2026-07-09-hao-740-attempt-1-objective-validation-repair.md',
     validation_repair_ref:
-      'data/virtual_ai_os/discovery/2026-07-08-vai-674-objective-validation-repair.md',
+      'data/hallucinate_multimodal_control/discovery/2026-07-09-hao-740-attempt-1-objective-validation-repair.md',
     attempt_validation_confirmation_ref:
-      'data/virtual_ai_os/discovery/2026-07-08-vai-674-attempt-8-validation-confirmation.md',
+      'data/hallucinate_multimodal_control/discovery/2026-07-09-hao-740-attempt-1-objective-validation-repair.md',
     retry_budget_ref:
+      'data/hallucinate_multimodal_control/discovery/2026-07-08-hao-751-hao-740-retry-budget.md',
+    related_validation_repair_ref:
+      'data/hallucinate_multimodal_control/discovery/2026-07-08-hao-751-hao-740-validation-repair.md',
+    legacy_vai_objective_gap_ref:
+      'data/virtual_ai_os/discovery/2026-07-08-vai-674-objective-gap-7edb316279e5.md',
+    legacy_vai_validation_repair_ref:
+      'data/virtual_ai_os/discovery/2026-07-08-vai-674-objective-validation-repair.md',
+    legacy_vai_attempt_validation_confirmation_ref:
+      'data/virtual_ai_os/discovery/2026-07-08-vai-674-attempt-8-validation-confirmation.md',
+    legacy_vai_retry_budget_ref:
       'data/virtual_ai_os/state/discovery/2026-07-08-vai-684-vai-674-retry-budget.md',
     evidence: 'objective validation repair',
   },

--- a/hallucinate_app/node/views/test_interface.html
+++ b/hallucinate_app/node/views/test_interface.html
@@ -100,7 +100,15 @@
     "/v1/mobile/orb/dispatch_glasses_response",
     "/v1/mobile/orb/diagnostics"
   ],
-  "artifacts": ["interaction_envelope", "policy_decision", "mediation_receipt"]
+  "artifacts": ["interaction_envelope", "policy_decision", "mediation_receipt"],
+  "validation": {
+    "task_id": "HAO-740",
+    "repair_task_id": "HAO-740",
+    "related_repair_task_id": "HAO-751",
+    "goal_id": "VAIOS-G707",
+    "objective_gap_ref": "data/hallucinate_multimodal_control/discovery/2026-07-08-hao-740-objective-gap-7edb316279e5.md",
+    "validation_repair_ref": "data/hallucinate_multimodal_control/discovery/2026-07-09-hao-740-attempt-1-objective-validation-repair.md"
+  }
 }</textarea>
             </div>
             <div class="module-test-results">

--- a/python/hallucinate_app/control_surface_mediator.py
+++ b/python/hallucinate_app/control_surface_mediator.py
@@ -30,16 +30,18 @@ from hallucinate_app.control_surface_logic_ir import (
 from hallucinate_app.control_surface_store import PolicyBundleStore, stable_cid
 
 
-MEDIATOR_VERSION = "0.1.0"
+MEDIATOR_VERSION = "0.1.1"
 DEFAULT_CONFLICT_RESOLUTION = "deny_over_permit"
+# Align with SwissKnife mcp-control-surface-mediator DEFAULT_FAIL_CLOSED_OUTCOME.
+DEFAULT_MISSING_POLICY_OUTCOME = DeonticOutcome.REQUIRE_CONFIRMATION.value
 DEFAULT_POLICY_BUNDLE_REF = {
-    "policy_id": "policy:default-runtime-allow",
-    "policy_cid": "local:default-runtime-allow",
+    "policy_id": "policy:default-runtime-fail-closed",
+    "policy_cid": "local:default-runtime-fail-closed",
     "version": MEDIATOR_VERSION,
     "scope": "runtime",
-    "source": "system_default",
+    "source": "system_fail_closed",
 }
-DEFAULT_COMPILED_POLICY_CID = "local:default-runtime-allow"
+DEFAULT_COMPILED_POLICY_CID = "local:default-runtime-fail-closed"
 
 SUPPORTED_OUTCOMES = (
     "allow",
@@ -208,6 +210,7 @@ class ControlSurfaceMediator:
         active_policy_bundles: list[Any] | tuple[Any, ...] | None = None,
         conflict_resolution: str | None = None,
         decided_at: str | None = None,
+        missing_policy_outcome: str | None = None,
     ) -> PolicyDecision:
         """Return a rich policy decision for a normalized interaction envelope."""
 
@@ -222,6 +225,7 @@ class ControlSurfaceMediator:
             active_policy_bundles=bundles,
             conflict_resolution=conflict_resolution or self.conflict_resolution,
             decided_at=decided_at,
+            missing_policy_outcome=missing_policy_outcome,
         )
 
 
@@ -231,8 +235,14 @@ def evaluate_control_surface_interaction(
     active_policy_bundles: list[Any] | tuple[Any, ...] | None = None,
     conflict_resolution: str = DEFAULT_CONFLICT_RESOLUTION,
     decided_at: str | None = None,
+    missing_policy_outcome: str | None = None,
 ) -> PolicyDecision:
-    """Evaluate one normalized interaction before the target method executes."""
+    """Evaluate one normalized interaction before the target method executes.
+
+    UIR-034: no-match / missing policy fails closed (default
+    ``require_confirmation``), matching SwissKnife TypeScript mediation.
+    Missing or empty policy bundles never allow execution.
+    """
 
     resolved_envelope = _coerce_envelope(envelope)
     envelope_payload = _decision_envelope_payload(envelope, resolved_envelope)
@@ -242,16 +252,20 @@ def evaluate_control_surface_interaction(
     matched = _matched_norms(resolved_envelope, bundles, frame_facts)
     selected = _select_match(matched, conflict_resolution)
     event_atoms = [fact.atom() for fact in event_facts]
+    fail_closed_outcome = _coerce_missing_policy_outcome(missing_policy_outcome)
 
     if selected is None:
-        effect = _default_allow_effect(resolved_envelope)
-        reasons = [_default_allow_reason(bundles)]
+        effect = _fail_closed_effect(resolved_envelope, outcome=fail_closed_outcome)
+        reasons = [_fail_closed_reason(bundles, fail_closed_outcome)]
         explanation = reasons[0]
         policy_bundle_ref = dict(DEFAULT_POLICY_BUNDLE_REF)
         compiled_policy_cid = DEFAULT_COMPILED_POLICY_CID
-        outcome = DeonticOutcome.ALLOW.value
+        outcome = fail_closed_outcome
         confidence = 1.0
-        selected_norm_id = "default_allow"
+        selected_norm_id = "fail_closed_no_match"
+        fail_closed_reason = (
+            "missing_policy_bundle" if not bundles else "no_matching_policy_norm"
+        )
     else:
         outcome = selected.outcome
         effect = _effect_for_decision(selected.norm, resolved_envelope)
@@ -261,6 +275,7 @@ def evaluate_control_surface_interaction(
         explanation = _explanation(reasons)
         confidence = _policy_confidence(selected, bundles)
         selected_norm_id = selected.norm.norm_id
+        fail_closed_reason = ""
 
     decided = decided_at or _utc_now()
     decision_id = stable_control_surface_id(
@@ -287,6 +302,9 @@ def evaluate_control_surface_interaction(
             }
             for bundle in bundles
         ],
+        "fail_closed": selected is None,
+        "fail_closed_reason": fail_closed_reason,
+        "missing_policy_outcome": fail_closed_outcome if selected is None else "",
     }
 
     return PolicyDecision(
@@ -609,14 +627,41 @@ def _logic_clause_refs(norm: ControlSurfaceNorm, bundle: ActivePolicyBundle) -> 
     return sorted(dict.fromkeys(ref for ref in refs if ref))
 
 
-def _default_allow_effect(envelope: InteractionEnvelope) -> InvocationEffect:
+def _coerce_missing_policy_outcome(value: str | None) -> str:
+    """Only deny or require_confirmation are valid fail-closed defaults."""
+
+    if value is None or value == "":
+        return DEFAULT_MISSING_POLICY_OUTCOME
+    normalized = str(value).strip()
+    allowed = {
+        DeonticOutcome.DENY.value,
+        DeonticOutcome.REQUIRE_CONFIRMATION.value,
+    }
+    if normalized not in allowed:
+        # Invalid configuration itself fails closed to confirmation.
+        return DeonticOutcome.REQUIRE_CONFIRMATION.value
+    return normalized
+
+
+def _fail_closed_effect(
+    envelope: InteractionEnvelope,
+    *,
+    outcome: str,
+) -> InvocationEffect:
     intent = envelope.normalized_intent
     return InvocationEffect.from_intent(
-        outcome=DeonticOutcome.ALLOW,
+        outcome=outcome,
         method=intent.method,
         target_ref=intent.target_ref,
         arguments=intent.arguments,
-        reason="No matching active policy blocked the invocation.",
+        reason="No matching active policy; fail-closed mediation blocks invocation.",
+    )
+
+
+# Back-compat alias (deprecated): previously default-allowed on no match.
+def _default_allow_effect(envelope: InteractionEnvelope) -> InvocationEffect:
+    return _fail_closed_effect(
+        envelope, outcome=DEFAULT_MISSING_POLICY_OUTCOME
     )
 
 
@@ -678,10 +723,21 @@ def _decision_reasons(
     return _dedupe_strings(reasons)
 
 
-def _default_allow_reason(bundles: list[ActivePolicyBundle]) -> str:
+def _fail_closed_reason(bundles: list[ActivePolicyBundle], outcome: str) -> str:
     if bundles:
-        return "No active policy norm matched; default allow permits the invocation."
-    return "No active policy bundles were supplied; default allow permits the invocation."
+        return (
+            "No active policy norm matched; fail-closed mediation returns "
+            f"{outcome} and does not permit the invocation."
+        )
+    return (
+        "No active policy bundles were supplied; fail-closed mediation returns "
+        f"{outcome} and does not permit the invocation."
+    )
+
+
+# Back-compat alias (deprecated).
+def _default_allow_reason(bundles: list[ActivePolicyBundle]) -> str:
+    return _fail_closed_reason(bundles, DEFAULT_MISSING_POLICY_OUTCOME)
 
 
 def _explanation(reasons: list[str]) -> str:

--- a/python/hallucinate_app/test/fixtures/control_surface_policy_corpus.json
+++ b/python/hallucinate_app/test/fixtures/control_surface_policy_corpus.json
@@ -276,7 +276,7 @@
     },
     {
       "id": "equivalent-display-focus-next",
-      "description": "Voice, gesture, mouse, and agent inputs normalize to display.focus_next and receive the same default allow explanation.",
+      "description": "Voice, gesture, mouse, and agent inputs normalize to display.focus_next and receive the same fail-closed explanation.",
       "policy_ids": [],
       "decided_at": "2026-05-24T17:00:01Z",
       "expected_intent": {
@@ -285,10 +285,10 @@
         "target_ref": "widget:list"
       },
       "expected_decision": {
-        "outcome": "allow",
+        "outcome": "require_confirmation",
         "effect_method": "focus_next",
         "effect_target_ref": "widget:list",
-        "explanation": "No active policy bundles were supplied; default allow permits the invocation."
+        "explanation": "No active policy bundles were supplied; fail-closed mediation returns require_confirmation and does not permit the invocation."
       },
       "cases": [
         {

--- a/python/hallucinate_app/test/test_control_surface_mediator.py
+++ b/python/hallucinate_app/test/test_control_surface_mediator.py
@@ -126,10 +126,15 @@ class TestControlSurfaceMediator(unittest.TestCase):
             decided_at="2026-05-24T12:15:01Z",
         )
 
-        self.assertEqual(decision.outcome, "allow")
-        self.assertTrue(decision.can_execute)
+        # UIR-034: no matching norm fails closed (never default-allows).
+        self.assertEqual(decision.outcome, "require_confirmation")
+        self.assertFalse(decision.can_execute)
         self.assertEqual(decision.matched_norms, [])
-        self.assertEqual(decision.effects[0].outcome, DeonticOutcome.ALLOW)
+        self.assertTrue(decision.metadata.get("fail_closed"))
+        self.assertEqual(
+            decision.effects[0].outcome,
+            DeonticOutcome.REQUIRE_CONFIRMATION.value,
+        )
 
     def test_confirmation_policy_blocks_execution_until_confirmed(self) -> None:
         policy = compile_strict_template_rule("require confirmation before sending messages")

--- a/python/hallucinate_app/test/test_control_surface_pointer.py
+++ b/python/hallucinate_app/test/test_control_surface_pointer.py
@@ -56,10 +56,12 @@ class TestControlSurfacePointer(unittest.TestCase):
         self.assertEqual(envelope["normalized_intent"]["method"], "activate")
         self.assertEqual(envelope["normalized_intent"]["target_ref"], "widget:primary-action")
         self.assertEqual(envelope["normalized_intent"]["arguments"]["button"], 0)
-        self.assertEqual(decision["outcome"], "allow")
-        self.assertTrue(resolution.can_execute)
+        # UIR-034: no active policy fails closed (never default-allows).
+        self.assertEqual(decision["outcome"], "require_confirmation")
+        self.assertFalse(resolution.can_execute)
         self.assertEqual(decision["effects"][0]["target_ref"], "widget:primary-action")
-        self.assertEqual(decision["metadata"]["mediator_version"], "0.1.0")
+        self.assertEqual(decision["metadata"]["mediator_version"], "0.1.1")
+        self.assertTrue(decision["metadata"]["fail_closed"])
 
     def test_touch_event_alias_resolves_to_click_with_touch_pointer_metadata(self) -> None:
         envelope = normalize_pointer_interaction(

--- a/python/hallucinate_app/test/test_control_surface_receipts.py
+++ b/python/hallucinate_app/test/test_control_surface_receipts.py
@@ -121,7 +121,7 @@ class TestControlSurfaceReceipts(unittest.TestCase):
             loaded = MediationReceiptStore(receipt_dir).load_receipt(record.receipt_cid)
             self.assertEqual(loaded["mediation_receipt"], receipt)
 
-    def test_default_allow_receipt_has_policy_ref_outcome_and_explanation(self) -> None:
+    def test_fail_closed_receipt_has_policy_ref_outcome_and_explanation(self) -> None:
         decision = evaluate_control_surface_interaction(
             _message_envelope(),
             active_policy_bundles=[],
@@ -140,10 +140,13 @@ class TestControlSurfaceReceipts(unittest.TestCase):
 
         self.receipt_validator.validate(receipt)
         self.assertEqual(first.receipt_id, second.receipt_id)
-        self.assertEqual(receipt["policy_refs"][0]["policy_bundle_ref"]["source"], "system_default")
-        self.assertEqual(receipt["mediation_result"]["outcome"], "allow")
-        self.assertTrue(receipt["mediation_result"]["invoked"])
-        self.assertIn("default allow", receipt["explanation"])
+        self.assertEqual(
+            receipt["policy_refs"][0]["policy_bundle_ref"]["source"],
+            "system_fail_closed",
+        )
+        self.assertEqual(receipt["mediation_result"]["outcome"], "require_confirmation")
+        self.assertFalse(receipt["mediation_result"]["invoked"])
+        self.assertIn("fail-closed", receipt["explanation"])
         self.assertEqual(receipt["metadata"]["surface"], "voice")
         self.assertEqual(receipt["metadata"]["normalized_intent"]["method"], "send_message")
 

--- a/python/hallucinate_app/test/test_control_surface_service_invocation.py
+++ b/python/hallucinate_app/test/test_control_surface_service_invocation.py
@@ -9,6 +9,12 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).parent.parent.parent))
 
+from hallucinate_app.control_surface_logic_ir import (  # noqa: E402
+    ControlSurfaceNorm,
+    ControlSurfacePolicy,
+    DeonticOutcome,
+    InvocationEffect,
+)
 from hallucinate_app.control_surface_policy import compile_strict_template_rule  # noqa: E402
 from hallucinate_app.control_surface_service_invocation import (  # noqa: E402
     ServiceInvocationMediationError,
@@ -68,6 +74,30 @@ class TestControlSurfaceServiceInvocation(unittest.TestCase):
 
     def test_allowed_invocation_calls_transport_after_mediation(self) -> None:
         observed: dict[str, object] = {}
+        # UIR-034: explicit allow norm required; empty policy no longer default-allows.
+        allow_policy = ControlSurfacePolicy(
+            policy_id="policy:allow-list-datasets",
+            compiled_policy_cid="compiled:allow-list-datasets",
+            norms=(
+                ControlSurfaceNorm(
+                    norm_id="allow-list-datasets",
+                    outcome=DeonticOutcome.ALLOW,
+                    priority=100,
+                    actor="user:*",
+                    surface="*",
+                    surface_event="*",
+                    method="list_datasets",
+                    target_ref="target:*",
+                    effect=InvocationEffect(
+                        outcome=DeonticOutcome.ALLOW,
+                        method="list_datasets",
+                        target_ref="target:*",
+                        reason="explicit allow for list_datasets",
+                    ),
+                    explanation="explicit allow for list_datasets",
+                ),
+            ),
+        )
 
         def invoke(payload, mediation):
             observed["payload"] = payload
@@ -83,6 +113,7 @@ class TestControlSurfaceServiceInvocation(unittest.TestCase):
                 "actor": {"type": "user", "id": "operator-7"},
             },
             invoke,
+            active_policy_bundles=[allow_policy],
             decided_at="2026-05-24T10:00:01Z",
             emitted_at="2026-05-24T10:00:02Z",
         )

--- a/python/hallucinate_app/test/test_control_surface_voice.py
+++ b/python/hallucinate_app/test/test_control_surface_voice.py
@@ -184,8 +184,9 @@ class TestControlSurfaceVoice(unittest.TestCase):
         )
 
         self.assertFalse(resolution.clarification_requested)
-        self.assertEqual(resolution.decision.outcome, "allow")
-        self.assertTrue(resolution.can_execute)
+        # Confidence gate passes; mediation still fail-closes without a matching norm.
+        self.assertEqual(resolution.decision.outcome, "require_confirmation")
+        self.assertFalse(resolution.can_execute)
         self.assertEqual(resolution.envelope.normalized_intent.method, "focus_next")
 
     def test_unknown_utterance_fails_closed_before_mediation(self) -> None:

--- a/python/hallucinate_app/test/test_ui_ux_ir_policy_parity.py
+++ b/python/hallucinate_app/test/test_ui_ux_ir_policy_parity.py
@@ -1,0 +1,223 @@
+"""UIR-034: Python/TypeScript mediation fail-closed policy parity.
+
+Aligns Hallucinate ``control_surface_mediator`` with SwissKnife
+``mcp-control-surface-mediator`` so no-match / missing / invalid policy never
+allows, and shared outcome vectors stay executor-spy safe.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parent.parent.parent))
+
+from hallucinate_app.control_surface_intents import normalize_interaction  # noqa: E402
+from hallucinate_app.control_surface_logic_ir import (  # noqa: E402
+    ControlSurfaceNorm,
+    ControlSurfacePolicy,
+    DeonticOutcome,
+    InvocationEffect,
+)
+from hallucinate_app.control_surface_mediator import (  # noqa: E402
+    DEFAULT_MISSING_POLICY_OUTCOME,
+    SUPPORTED_OUTCOMES,
+    evaluate_control_surface_interaction,
+)
+from hallucinate_app.control_surface_policy import compile_strict_template_rule  # noqa: E402
+
+# Shared closed outcome catalogue (TS ControlSurfaceOutcome + Python SUPPORTED_OUTCOMES).
+SHARED_OUTCOMES = (
+    "allow",
+    "deny",
+    "require_confirmation",
+    "defer",
+    "rewrite",
+    "fallback_surface",
+    "rate_limit",
+)
+
+# SwissKnife DEFAULT_FAIL_CLOSED_OUTCOME
+TS_FAIL_CLOSED_DEFAULT = "require_confirmation"
+
+
+def _envelope(
+    *,
+    interaction_id: str = "parity-001",
+    method: str = "send_message",
+    confidence: float = 0.95,
+):
+    return normalize_interaction(
+        interaction_id=interaction_id,
+        surface="voice",
+        surface_event="utterance",
+        raw_payload={"text": "send it"},
+        normalized_intent={
+            "intent": "communication.send",
+            "method": method,
+            "target_ref": "service:messaging",
+            "arguments": {"body": "hello"},
+            "confidence": confidence,
+        },
+        actor={"type": "user", "id": "operator-7", "delegation_chain": ["operator-7"]},
+        context={
+            "local_time": "2026-05-24T10:00:00-07:00",
+            "state_frames": [],
+            "device_mode": "",
+            "platform": "hallucinate_app",
+        },
+    )
+
+
+def _allow_norm(method: str = "send_message") -> ControlSurfacePolicy:
+    return ControlSurfacePolicy(
+        policy_id="policy:parity-allow",
+        compiled_policy_cid="compiled:parity-allow",
+        norms=(
+            ControlSurfaceNorm(
+                norm_id="norm:parity-allow",
+                outcome=DeonticOutcome.ALLOW,
+                priority=50,
+                actor="user:*",
+                surface="*",
+                surface_event="*",
+                method=method,
+                target_ref="target:*",
+                effect=InvocationEffect(
+                    outcome=DeonticOutcome.ALLOW,
+                    method=method,
+                    target_ref="target:*",
+                    reason="parity allow",
+                ),
+                explanation="parity allow",
+            ),
+        ),
+    )
+
+
+class TestUIUXIRPolicyParity(unittest.TestCase):
+    """Shared policy vectors and executor-spy fail-closed receipt."""
+
+    def test_supported_outcomes_match_typescript_catalogue(self) -> None:
+        self.assertEqual(tuple(SUPPORTED_OUTCOMES), SHARED_OUTCOMES)
+        self.assertEqual(DEFAULT_MISSING_POLICY_OUTCOME, TS_FAIL_CLOSED_DEFAULT)
+
+    def test_no_match_and_missing_policy_cannot_allow(self) -> None:
+        empty = evaluate_control_surface_interaction(
+            _envelope(interaction_id="parity-empty"),
+            active_policy_bundles=[],
+            decided_at="2026-05-24T10:00:01Z",
+        )
+        self.assertEqual(empty.outcome, "require_confirmation")
+        self.assertFalse(empty.can_execute)
+        self.assertTrue(empty.metadata.get("fail_closed"))
+        self.assertEqual(empty.metadata.get("fail_closed_reason"), "missing_policy_bundle")
+
+        # Policy present but no norm matches the method.
+        quiet = compile_strict_template_rule(
+            "Ignore my wrist gestures at night, because I'm sleeping.",
+            timezone="America/Los_Angeles",
+        )
+        no_match = evaluate_control_surface_interaction(
+            _envelope(interaction_id="parity-no-match"),
+            active_policy_bundles=[quiet],
+            decided_at="2026-05-24T10:00:01Z",
+        )
+        self.assertNotEqual(no_match.outcome, "allow")
+        self.assertFalse(no_match.can_execute)
+        self.assertTrue(no_match.metadata.get("fail_closed"))
+
+    def test_invalid_missing_policy_outcome_config_fails_closed(self) -> None:
+        decision = evaluate_control_surface_interaction(
+            _envelope(interaction_id="parity-invalid-cfg"),
+            active_policy_bundles=[],
+            missing_policy_outcome="allow",  # invalid — must not honor
+            decided_at="2026-05-24T10:00:01Z",
+        )
+        self.assertEqual(decision.outcome, "require_confirmation")
+        self.assertFalse(decision.can_execute)
+
+    def test_missing_policy_outcome_deny_vector(self) -> None:
+        decision = evaluate_control_surface_interaction(
+            _envelope(interaction_id="parity-deny-cfg"),
+            active_policy_bundles=[],
+            missing_policy_outcome="deny",
+            decided_at="2026-05-24T10:00:01Z",
+        )
+        self.assertEqual(decision.outcome, "deny")
+        self.assertFalse(decision.can_execute)
+
+    def test_shared_outcome_vectors_with_executor_spy(self) -> None:
+        vectors = [
+            ("require confirmation before sending messages", "require_confirmation"),
+            ("Ignore my wrist gestures at night, because I'm sleeping.", "require_confirmation"),
+        ]
+        for rule, expected in vectors:
+            with self.subTest(rule=rule, expected=expected):
+                policy = compile_strict_template_rule(rule, timezone="America/Los_Angeles")
+                decision = evaluate_control_surface_interaction(
+                    _envelope(interaction_id=f"parity-{expected}"),
+                    active_policy_bundles=[policy],
+                    decided_at="2026-05-24T10:00:01Z",
+                )
+                # Confirmation template matches send_message; quiet-hours does not.
+                if "sending messages" in rule:
+                    self.assertEqual(decision.outcome, "require_confirmation")
+                else:
+                    # No match → fail closed (not allow).
+                    self.assertNotEqual(decision.outcome, "allow")
+                self.assertFalse(decision.can_execute)
+
+                calls: list = []
+
+                def spy(_req=None, **_kwargs):  # type: ignore[no-untyped-def]
+                    calls.append(True)
+                    return "executed"
+
+                if decision.can_execute:
+                    spy()
+                self.assertEqual(calls, [])
+
+    def test_explicit_allow_reaches_executor_spy_once(self) -> None:
+        decision = evaluate_control_surface_interaction(
+            _envelope(interaction_id="parity-allow"),
+            active_policy_bundles=[_allow_norm()],
+            decided_at="2026-05-24T10:00:01Z",
+        )
+        self.assertEqual(decision.outcome, "allow")
+        self.assertTrue(decision.can_execute)
+
+        calls: list = []
+
+        def spy():  # type: ignore[no-untyped-def]
+            calls.append(decision.decision_id)
+            return {"ok": True}
+
+        if decision.can_execute:
+            result = spy()
+        else:
+            result = None
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(len(calls), 1)
+
+    def test_decision_identities_remain_compatible(self) -> None:
+        decision = evaluate_control_surface_interaction(
+            _envelope(interaction_id="parity-identity"),
+            active_policy_bundles=[],
+            decided_at="2026-05-24T10:00:01Z",
+        )
+        payload = decision.as_dict()
+        self.assertTrue(payload["decision_id"])
+        self.assertEqual(payload["interaction_id"], "parity-identity")
+        self.assertIn("policy_bundle_ref", payload)
+        self.assertIn("compiled_policy_cid", payload)
+        self.assertIn("reasons", payload)
+        self.assertIn("explanation", payload)
+        self.assertIn("effects", payload)
+        self.assertFalse(payload["metadata"]["can_execute"])
+        self.assertEqual(payload["policy_bundle_ref"]["source"], "system_fail_closed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/run_playwright_test.mjs
+++ b/scripts/run_playwright_test.mjs
@@ -13,7 +13,9 @@ const electronPackage = path.join(projectRoot, 'node_modules', 'electron', 'pack
 const commandArgs = process.argv.slice(2);
 const args = commandArgs.length > 0 ? commandArgs : ['test'];
 const missingDisplayDiagnostic = 'missing_xvfb_for_electron_playwright';
-const noDisplayLaunchGateSpecs = new Set([
+// Spec basenames that may execute without a graphical display (VAI-533).
+// Electron UI coverage is not claimed for these no-display runnable gates.
+const NO_DISPLAY_RUNNABLE_SPEC_FILES = new Set([
   'daemon-launch-health.spec.ts',
   'mcp-feature-exposure.spec.ts',
   'mcp-dashboard-interoperability.spec.ts',
@@ -24,12 +26,6 @@ const specSourceDisplayPatterns = [
   'electron.launch(',
   'ElectronApplication',
 ];
-const headlessStaticCoverageSpecs = new Set([
-  'daemon-launch-health.spec.ts',
-  'mcp-feature-exposure.spec.ts',
-  'mcp-dashboard-interoperability.spec.ts',
-  'multimodal-control-surface.spec.ts',
-]);
 
 runPlaywright(args);
 
@@ -83,8 +79,8 @@ function runPlaywright(playwrightArgs) {
   if (command.usesXvfb) {
     console.warn('No graphical display detected; running Hallucinate Electron Playwright tests under xvfb-run.');
   }
-  if (command.headlessGate) {
-    console.warn('No graphical display detected; running headless-compatible launch gate specs without Electron UI coverage.');
+  if (command.noDisplayRunnableGate) {
+    console.warn('No graphical display detected; running no-display runnable launch gate specs without Electron UI coverage.');
   }
 
   const status = run(command.binary, command.args, command.env || {});
@@ -97,14 +93,14 @@ function playwrightCommand(playwrightArgs) {
     return { binary: process.execPath, args: baseArgs };
   }
 
-  if (canRunWithoutVirtualDisplay(playwrightArgs)) {
+  if (isNoDisplayRunnableRequest(playwrightArgs)) {
     return {
       binary: process.execPath,
       args: baseArgs,
       env: {
         HALLUCINATE_APP_E2E_HEADLESS_GATE: 'true',
       },
-      headlessGate: true,
+      noDisplayRunnableGate: true,
     };
   }
 
@@ -129,7 +125,7 @@ function playwrightCommand(playwrightArgs) {
   };
 }
 
-function canRunWithoutVirtualDisplay(playwrightArgs) {
+function isNoDisplayRunnableRequest(playwrightArgs) {
   return !selectedTestsNeedDisplay(playwrightArgs);
 }
 
@@ -155,7 +151,7 @@ function selectedTestsNeedDisplay(playwrightArgs) {
     return true;
   }
 
-  if (specPaths.every((specPath) => headlessStaticCoverageSpecs.has(path.basename(specPath)))) {
+  if (specPaths.every((specPath) => NO_DISPLAY_RUNNABLE_SPEC_FILES.has(path.basename(specPath)))) {
     return false;
   }
 


### PR DESCRIPTION
## Summary
Merges the previously monorepo-pinned hallucinate tip (`da8a6a6`) onto current `main`:
- UIR-034 fail-closed no-match mediation
- UI/UX IR policy parity tests
- VAI-533 Playwright no-display runner alignment
- HAO-740 mobile interop descriptor export

## Conflict resolution
- `search_interface.js`: kept UIR branch `HALLUCINATE_APP_MOBILE_INTEROP_DESCRIPTOR` export
- `ipfs_accelerate_py` gitlink: kept **main** pin (not the older nested pin)

## Test plan
- [ ] Python control-surface tests under `python/hallucinate_app/test/`
- [ ] Confirm `scripts/run_playwright_test.mjs` still runs with no display